### PR TITLE
feat: auto-link Linear/Jira tickets in PR descriptions from branch name

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -42,6 +42,7 @@ var configShowCmd = &cobra.Command{
 		fmt.Printf("stale_threshold_days = %d\n", cfg.StaleThresholdDays)
 		fmt.Printf("default_remote       = %q\n", cfg.DefaultRemote)
 		fmt.Printf("default_base         = %q\n", cfg.DefaultBase)
+		fmt.Printf("ticket_pattern       = %q\n", cfg.TicketPattern)
 		return nil
 	},
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/sauravpanda/bonsai/internal/config"
@@ -101,6 +102,14 @@ func runPush(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Println("  opening PR ...")
 			prArgs := []string{"pr", "create", "--fill"}
+
+			// Ticket auto-linking: extract ticket IDs from the branch name and
+			// prepend them to the PR body so Linear/Jira recognise the reference.
+			if ticketRef := extractTicket(wt.Branch, cfg.TicketPattern); ticketRef != "" {
+				prArgs = append(prArgs, "--body", ticketRef+"\n\n")
+				fmt.Printf("  ticket   : %s\n", ticketRef)
+			}
+
 			if web {
 				prArgs = append(prArgs, "--web")
 			}
@@ -130,6 +139,27 @@ func runPush(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// extractTicket returns the first ticket ID found in branch using the configured
+// regexp pattern. Returns "" if pattern is empty or no match.
+func extractTicket(branch, pattern string) string {
+	if pattern == "" {
+		return ""
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return ""
+	}
+	m := re.FindStringSubmatch(branch)
+	if len(m) < 2 {
+		// No capture group match — try full match.
+		if re.MatchString(branch) {
+			return re.FindString(branch)
+		}
+		return ""
+	}
+	return m[1]
 }
 
 // resolveWorktree finds the worktree matching the given arg (path or branch),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,10 @@ type Config struct {
 	StaleThresholdDays int    `toml:"stale_threshold_days"`
 	DefaultRemote      string `toml:"default_remote"`
 	DefaultBase        string `toml:"default_base"`
+	// TicketPattern is a Go regexp with a capturing group that extracts a
+	// ticket ID from a branch name (e.g. "([A-Z]+-\\d+)").
+	// If empty, ticket auto-linking is disabled.
+	TicketPattern string `toml:"ticket_pattern"`
 }
 
 func Default() *Config {
@@ -21,6 +25,7 @@ func Default() *Config {
 		StaleThresholdDays: 14,
 		DefaultRemote:      "origin",
 		DefaultBase:        "main",
+		TicketPattern:      `([A-Z]+-\d+)`,
 	}
 }
 


### PR DESCRIPTION
Adds ticket_pattern config (default: ([A-Z]+-\d+)). When bonsai push --pr runs, extractTicket() finds the first match in the branch name and prepends it to the PR body. Falls back gracefully (no match = no change). bonsai config show now shows ticket_pattern. Closes #19