### PR TITLE
feat: goreleaser, release workflow, and code review fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+version: 2
+project_name: bonsai
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/sauravpanda/bonsai/cmd.Version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: sauravpanda
+    name: bonsai
+  draft: false
+  prerelease: auto

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -65,7 +65,9 @@ func runNew(cmd *cobra.Command, args []string) error {
 	fetchCmd := exec.Command("git", "fetch", cfg.DefaultRemote, base)
 	fetchCmd.Stdout = os.Stdout
 	fetchCmd.Stderr = os.Stderr
-	_ = fetchCmd.Run() // non-fatal if offline
+	if err := fetchCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: fetch %s/%s failed (offline?): %v\n", cfg.DefaultRemote, base, err)
+	}
 
 	// git worktree add <path> -b <branch> <base>
 	addArgs := []string{"worktree", "add", wtPath, "-b", branch, cfg.DefaultRemote + "/" + base}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version is set at build time via -ldflags "-X github.com/sauravpanda/bonsai/cmd.Version=vX.Y.Z".
+var Version = "dev"
+
 var rootCmd = &cobra.Command{
 	Use:   "bonsai",
 	Short: "Git worktree manager",
@@ -12,6 +15,12 @@ var rootCmd = &cobra.Command{
 As AI-assisted workflows accumulate worktrees, bonsai gives you
 audit, clean, and finalize them with ease.`,
 	SilenceUsage: true, // don't print usage block on runtime errors
+}
+
+func init() {
+	// Version is injected by ldflags at build time; apply it here so the
+	// assignment happens after ldflags have been processed.
+	rootCmd.Version = Version
 }
 
 // Execute runs the root command.

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -96,7 +96,7 @@ func runSnapshotCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	branch := strings.ReplaceAll(wt.Branch, "/", "-")
-	ts := time.Now().Format("20060102-150405")
+	ts := time.Now().UTC().Format("20060102-150405")
 	archiveName := fmt.Sprintf("%s-%s.tar.gz", branch, ts)
 	archivePath := filepath.Join(dir, archiveName)
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -99,10 +99,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			return nil
 		})
 	}
-	g.Wait() //nolint:errcheck
+	if err := g.Wait(); err != nil {
+		return err
+	}
 	spin.Stop()
 
-	root, _ := git.MainRoot()
 	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9
 
 	hdr := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
@@ -113,8 +114,6 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	for _, s := range statuses {
 		wt := s.wt
-		path := git.ShortenPath(wt.Path, root)
-		_ = path
 
 		branch := wt.Branch
 		if wt.IsMain {

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -127,8 +127,8 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fm := final.(switchModel)
-	if fm.quit || fm.selected == "" {
+	fm, ok := final.(switchModel)
+	if !ok || fm.quit || fm.selected == "" {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` for cross-platform binary releases (linux/darwin/windows × amd64/arm64)
- Add `.github/workflows/release.yml` triggered on `v*` tag push
- Inject version at build time via `-ldflags` into `cmd.Version` (shows in `bonsai --version`)
- Fix unchecked type assertion panic in `cmd/switch.go`
- Fix silent fetch error in `cmd/new.go` (now warns to stderr)
- Fix unused `root`/`path` dead code in `cmd/status.go`
- Fix `g.Wait()` error now captured instead of ignored in `cmd/status.go`
- Fix snapshot timestamps to use UTC instead of local time

## To release
```bash
git tag v0.1.0
git push origin v0.1.0
```
The release workflow will build binaries for all platforms and create a GitHub Release automatically.