### PR TITLE
Fix worktree edge cases and snapshot restore

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -70,8 +71,10 @@ func runClean(cmd *cobra.Command, args []string) error {
 				if err == nil {
 					wt.PRStatus = strings.ToLower(pr.State)
 					wt.PRURL = pr.URL
-				} else {
+				} else if errors.Is(err, github.ErrNoPR) {
 					wt.PRStatus = "none"
+				} else {
+					wt.PRStatus = "unknown"
 				}
 			}
 			return nil
@@ -189,7 +192,7 @@ func candidateReasons(wt *git.Worktree, staleDur float64) []string {
 	if wt.Age > 0 && float64(wt.Age) > staleDur {
 		reasons = append(reasons, fmt.Sprintf("stale (%s)", git.FormatAge(wt.Age)))
 	}
-	if !wt.HasUnpushed && wt.PRStatus != "open" && wt.PRStatus != "merged" {
+	if !wt.HasUnpushed && (wt.PRStatus == "" || wt.PRStatus == "none") {
 		reasons = append(reasons, "no unpushed commits")
 	}
 	return reasons

--- a/cmd/exec_helpers.go
+++ b/cmd/exec_helpers.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func commandWithPathArg(commandLine, path string) (*exec.Cmd, error) {
+	parts, err := splitCommandLine(commandLine)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("no editor found; set $EDITOR or use --editor")
+	}
+	return exec.Command(parts[0], append(parts[1:], path)...), nil
+}
+
+func splitCommandLine(s string) ([]string, error) {
+	var (
+		parts   []string
+		current []rune
+		quote   rune
+		escape  bool
+	)
+
+	flush := func() {
+		if len(current) > 0 {
+			parts = append(parts, string(current))
+			current = nil
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case escape:
+			current = append(current, r)
+			escape = false
+		case r == '\\':
+			escape = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				current = append(current, r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+		case r == ' ' || r == '\t' || r == '\n':
+			flush()
+		default:
+			current = append(current, r)
+		}
+	}
+
+	if escape {
+		current = append(current, '\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in command: %q", s)
+	}
+	flush()
+	return parts, nil
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sauravpanda/bonsai/internal/git"
+)
+
+func TestCommandWithPathArg(t *testing.T) {
+	cmd, err := commandWithPathArg("code -r", "/tmp/worktree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cmd.Path, "code"; got != want {
+		t.Fatalf("cmd.Path = %q, want %q", got, want)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "-r" || cmd.Args[2] != "/tmp/worktree" {
+		t.Fatalf("unexpected args: %#v", cmd.Args)
+	}
+}
+
+func TestCommandWithPathArgSupportsQuotedArgs(t *testing.T) {
+	cmd, err := commandWithPathArg(`"Visual Studio Code" --reuse-window`, "/tmp/worktree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cmd.Path, "Visual Studio Code"; got != want {
+		t.Fatalf("cmd.Path = %q, want %q", got, want)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "--reuse-window" || cmd.Args[2] != "/tmp/worktree" {
+		t.Fatalf("unexpected args: %#v", cmd.Args)
+	}
+}
+
+func TestCandidateReasonsDoesNotTreatUnknownPRAsNoPR(t *testing.T) {
+	reasons := candidateReasons(&git.Worktree{
+		Age:         time.Hour,
+		PRStatus:    "unknown",
+		HasUnpushed: false,
+	}, float64(14*24*time.Hour))
+
+	for _, reason := range reasons {
+		if reason == "no unpushed commits" {
+			t.Fatalf("unexpected reason set: %v", reasons)
+		}
+	}
+}
+
+func TestInspectSnapshotPrefersOriginalPathMetadata(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "snapshot.tar.gz")
+	if err := writeTestSnapshot(archive, "/tmp/original/path", "branch-dir"); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := inspectSnapshot(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.OriginalPath, "/tmp/original/path"; got != want {
+		t.Fatalf("OriginalPath = %q, want %q", got, want)
+	}
+	if got, want := info.RootDir, "branch-dir"; got != want {
+		t.Fatalf("RootDir = %q, want %q", got, want)
+	}
+}
+
+func TestExtractTarGzAllowsRelativeDestination(t *testing.T) {
+	root := t.TempDir()
+	archive := filepath.Join(root, "snapshot.tar.gz")
+	if err := writeTestSnapshot(archive, "/tmp/original/path", "branch-dir"); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+
+	restoreDir := filepath.Join(root, "restore")
+	if err := os.MkdirAll(restoreDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(restoreDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractTarGz(archive, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(restoreDir, "branch-dir", "file.txt")); err != nil {
+		t.Fatalf("restored file missing: %v", err)
+	}
+}
+
+func writeTestSnapshot(path, originalPath, rootDir string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	meta := []byte(originalPath + "\n")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: snapshotMetaName,
+		Mode: 0o600,
+		Size: int64(len(meta)),
+	}); err != nil {
+		return err
+	}
+	if _, err := tw.Write(meta); err != nil {
+		return err
+	}
+
+	content := []byte("hello")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: rootDir + "/file.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		return err
+	}
+	_, err = tw.Write(content)
+	return err
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -108,8 +109,10 @@ func runList(cmd *cobra.Command, args []string) error {
 				if err == nil {
 					wt.PRStatus = strings.ToLower(pr.State)
 					wt.PRURL = pr.URL
-				} else {
+				} else if errors.Is(err, github.ErrNoPR) {
 					wt.PRStatus = "none"
+				} else {
+					wt.PRStatus = "unknown"
 				}
 			} else if wt.IsMain {
 				wt.PRStatus = "—"

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -96,7 +96,10 @@ func runNew(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, "  note: $EDITOR not set, skipping --open")
 			return nil
 		}
-		openCmd := exec.Command(editor, wtPath)
+		openCmd, err := commandWithPathArg(editor, wtPath)
+		if err != nil {
+			return err
+		}
 		openCmd.Stdout = os.Stdout
 		openCmd.Stderr = os.Stderr
 		openCmd.Stdin = os.Stdin

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -85,7 +85,10 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("  opening %s in %s…\n", wt.Branch, editor)
-	openCmd := exec.Command(editor, wt.Path)
+	openCmd, err := commandWithPathArg(editor, wt.Path)
+	if err != nil {
+		return err
+	}
 	openCmd.Stdout = os.Stdout
 	openCmd.Stderr = os.Stderr
 	openCmd.Stdin = os.Stdin

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -88,8 +89,10 @@ func runPrune(cmd *cobra.Command, args []string) error {
 				if err == nil {
 					wt.PRStatus = strings.ToLower(pr.State)
 					wt.PRURL = pr.URL
-				} else {
+				} else if errors.Is(err, github.ErrNoPR) {
 					wt.PRStatus = "none"
+				} else {
+					wt.PRStatus = "unknown"
 				}
 			}
 			return nil

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -48,6 +48,8 @@ var snapshotRestoreCmd = &cobra.Command{
 	RunE:  runSnapshotRestore,
 }
 
+const snapshotMetaName = ".bonsai-snapshot-path"
+
 func init() {
 	rootCmd.AddCommand(snapshotCmd)
 	snapshotCmd.AddCommand(snapshotCreateCmd)
@@ -166,10 +168,16 @@ func runSnapshotRestore(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("snapshot not found: %s", target)
 	}
 
-	// Determine destination from archive contents.
-	dest, err := tarGzRootDir(target)
+	info, err := inspectSnapshot(target)
 	if err != nil {
 		return fmt.Errorf("inspect archive: %w", err)
+	}
+	dest := info.OriginalPath
+	if dest == "" {
+		dest = info.RootDir
+	}
+	if dest == "" {
+		return fmt.Errorf("snapshot does not contain a restore destination")
 	}
 
 	fmt.Printf("  restoring %s to %s … ", filepath.Base(target), dest)
@@ -194,6 +202,9 @@ func createTarGz(srcDir, destFile string) error {
 	defer tw.Close()
 
 	base := filepath.Base(srcDir)
+	if err := writeSnapshotMetadata(tw, srcDir); err != nil {
+		return err
+	}
 	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip unreadable entries
@@ -227,30 +238,56 @@ func createTarGz(srcDir, destFile string) error {
 	})
 }
 
-func tarGzRootDir(archivePath string) (string, error) {
+type snapshotInfo struct {
+	RootDir      string
+	OriginalPath string
+}
+
+func inspectSnapshot(archivePath string) (snapshotInfo, error) {
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return "", err
+		return snapshotInfo{}, err
 	}
 	defer f.Close()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
-		return "", err
+		return snapshotInfo{}, err
 	}
 	defer gz.Close()
 
 	tr := tar.NewReader(gz)
-	hdr, err := tr.Next()
-	if err != nil {
-		return "", err
+	var info snapshotInfo
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return snapshotInfo{}, err
+		}
+		if hdr.Name == snapshotMetaName {
+			body, err := io.ReadAll(tr)
+			if err != nil {
+				return snapshotInfo{}, err
+			}
+			info.OriginalPath = strings.TrimSpace(string(body))
+			continue
+		}
+		if info.RootDir == "" {
+			parts := strings.SplitN(hdr.Name, "/", 2)
+			info.RootDir = parts[0]
+		}
 	}
-	// Return the top-level directory in the archive.
-	parts := strings.SplitN(hdr.Name, "/", 2)
-	return parts[0], nil
+	return info, nil
 }
 
 func extractTarGz(archivePath, destDir string) error {
+	absDestDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return err
+	}
+
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return err
@@ -273,9 +310,12 @@ func extractTarGz(archivePath, destDir string) error {
 			return err
 		}
 
-		// Sanitize path to prevent directory traversal.
-		target := filepath.Join(destDir, filepath.Clean("/"+hdr.Name))
-		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) {
+		target := filepath.Join(absDestDir, hdr.Name)
+		rel, err := filepath.Rel(absDestDir, target)
+		if err != nil {
+			return err
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 			continue // skip suspicious paths
 		}
 
@@ -285,6 +325,9 @@ func extractTarGz(archivePath, destDir string) error {
 				return err
 			}
 		case tar.TypeReg:
+			if hdr.Name == snapshotMetaName {
+				continue
+			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
@@ -300,4 +343,18 @@ func extractTarGz(archivePath, destDir string) error {
 		}
 	}
 	return nil
+}
+
+func writeSnapshotMetadata(tw *tar.Writer, srcDir string) error {
+	body := []byte(srcDir + "\n")
+	hdr := &tar.Header{
+		Name: snapshotMetaName,
+		Mode: 0o600,
+		Size: int64(len(body)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := tw.Write(body)
+	return err
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -88,8 +89,10 @@ func runStats(cmd *cobra.Command, args []string) error {
 				if err == nil {
 					wt.PRStatus = strings.ToLower(pr.State)
 					wt.PRURL = pr.URL
-				} else {
+				} else if errors.Is(err, github.ErrNoPR) {
 					wt.PRStatus = "none"
+				} else {
+					wt.PRStatus = "unknown"
 				}
 			}
 			return nil

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -81,7 +81,7 @@ func Enrich(wt *Worktree, base, remote string) {
 	}
 
 	wt.AheadBase, wt.BehindBase = aheadBehind(wt.Path, wt.Branch, base, remote)
-	wt.HasUnpushed = hasUnpushed(wt.Path, wt.Branch, remote)
+	wt.HasUnpushed = hasUnpushed(wt.Path, wt.Branch, base, remote)
 }
 
 func aheadBehind(path, branch, base, remote string) (int, int) {
@@ -102,14 +102,19 @@ func aheadBehind(path, branch, base, remote string) (int, int) {
 	return a, b
 }
 
-func hasUnpushed(path, branch, remote string) bool {
+func hasUnpushed(path, branch, base, remote string) bool {
 	remoteRef := remote + "/" + branch
 	out, err := runIn(path, "git", "rev-list", "--count", remoteRef+".."+branch)
 	if err != nil {
-		// Remote branch doesn't exist — count all local commits as unpushed.
-		out2, err2 := runIn(path, "git", "rev-list", "--count", branch)
+		// No remote branch exists yet. Count only commits unique to this branch
+		// relative to the configured base branch instead of the full history.
+		baseRef := remote + "/" + base
+		out2, err2 := runIn(path, "git", "rev-list", "--count", baseRef+".."+branch)
 		if err2 != nil {
-			return false
+			out2, err2 = runIn(path, "git", "rev-list", "--count", base+".."+branch)
+			if err2 != nil {
+				return false
+			}
 		}
 		n, _ := strconv.Atoi(strings.TrimSpace(out2))
 		return n > 0

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,21 @@
+package git
+
+import "testing"
+
+func TestParseRelativeAge(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"3 days ago", "72h0m0s"},
+		{"2 weeks ago", "336h0m0s"},
+		{"15 minutes ago", "15m0s"},
+		{"bad input", "0s"},
+	}
+
+	for _, tt := range tests {
+		if got := ParseRelativeAge(tt.in).String(); got != tt.want {
+			t.Fatalf("ParseRelativeAge(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -2,8 +2,10 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // PRInfo holds pull request metadata.
@@ -13,6 +15,8 @@ type PRInfo struct {
 	State  string `json:"state"` // OPEN, CLOSED, MERGED
 	URL    string `json:"url"`
 }
+
+var ErrNoPR = errors.New("no pull request for branch")
 
 // IsAvailable returns true if gh CLI is installed and authenticated.
 func IsAvailable() bool {
@@ -24,9 +28,14 @@ func GetPR(branch string) (*PRInfo, error) {
 	out, err := exec.Command(
 		"gh", "pr", "view", branch,
 		"--json", "number,title,state,url",
-	).Output()
+	).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("no PR for branch %q", branch)
+		msg := strings.ToLower(string(out))
+		if strings.Contains(msg, "no pull requests found") ||
+			strings.Contains(msg, "could not find pull request") {
+			return nil, fmt.Errorf("%w: %q", ErrNoPR, branch)
+		}
+		return nil, fmt.Errorf("gh pr view %q: %w", branch, err)
 	}
 	var pr PRInfo
 	if err := json.Unmarshal(out, &pr); err != nil {
@@ -34,4 +43,3 @@ func GetPR(branch string) (*PRInfo, error) {
 	}
 	return &pr, nil
 }
-


### PR DESCRIPTION
## Summary
- fix unpushed detection for branches that do not have a remote yet
- preserve original snapshot restore destinations and harden tar extraction
- distinguish GitHub lookup failures from true no-PR cases
- support editor commands with arguments and add regression tests

## Testing
- go test ./...