### PR TITLE
Centralize styles, add list --json, fix clean candidate logic and UX

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -21,12 +21,12 @@ var cleanCmd = &cobra.Command{
 	Long: `Launch an interactive TUI to select and delete worktrees.
 
 Candidates are worktrees with:
-  - A merged GitHub PR
+  - A merged GitHub PR, or
   - No activity for longer than the stale threshold (default 14 days)
-  - No unpushed commits
 
-Worktrees with unpushed commits can still be selected but require
-explicit confirmation.`,
+Candidates with no unpushed commits are marked as such; candidates with
+unpushed commits can still be selected but require explicit confirmation.
+Use --all to list every worktree regardless of candidacy.`,
 	RunE: runClean,
 }
 
@@ -60,13 +60,20 @@ func runClean(cmd *cobra.Command, args []string) error {
 	ghOK := !offline && github.IsAvailable()
 	root, _ := git.MainRoot()
 
-	spin := tui.Start(fmt.Sprintf("enriching %d worktree(s) in parallel…", len(worktrees)))
-	var g errgroup.Group
+	var added []*git.Worktree
 	for _, wt := range worktrees {
+		if !wt.IsMain {
+			added = append(added, wt)
+		}
+	}
+
+	spin := tui.Start(fmt.Sprintf("enriching %d worktree(s) in parallel…", len(added)))
+	var g errgroup.Group
+	for _, wt := range added {
 		wt := wt
 		g.Go(func() error {
 			git.Enrich(wt, cfg.DefaultBase, cfg.DefaultRemote)
-			if ghOK && !wt.IsMain && !wt.IsDetached && wt.Branch != "" {
+			if ghOK && !wt.IsDetached && wt.Branch != "" {
 				pr, err := github.GetPR(wt.Branch)
 				if err == nil {
 					wt.PRStatus = strings.ToLower(pr.State)
@@ -86,18 +93,14 @@ func runClean(cmd *cobra.Command, args []string) error {
 	staleDur := staleDuration(cfg.StaleThresholdDays)
 
 	var items []tui.Item
-	for _, wt := range worktrees {
-		if wt.IsMain {
-			continue
-		}
-
+	for _, wt := range added {
 		reasons := candidateReasons(wt, staleDur)
 		if !showAll && len(reasons) == 0 {
 			continue
 		}
 
 		path := git.ShortenPath(wt.Path, root)
-		label := fmt.Sprintf("%-28s  %s", truncate(wt.Branch, 28), truncate(path, 40))
+		label := fmt.Sprintf("%-28s  %s", truncate(wt.Branch, 28), truncateLeft(path, 40))
 
 		desc := ""
 		if len(reasons) > 0 {
@@ -165,7 +168,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 	// Execute deletions
 	ok, failed := 0, 0
 	for _, it := range toDelete {
-		fmt.Printf("  removing %s ... ", it.ID)
+		fmt.Printf("  removing %s ... ", git.ShortenPath(it.ID, root))
 		if err := git.Remove(it.ID, force || it.HasUnpushed); err != nil {
 			fmt.Printf("error: %v\n", err)
 			failed++
@@ -200,7 +203,10 @@ func candidateReasons(wt *git.Worktree, staleDur float64) []string {
 	if wt.Age > 0 && float64(wt.Age) > staleDur {
 		reasons = append(reasons, fmt.Sprintf("stale (%s)", git.FormatAge(wt.Age)))
 	}
-	if !wt.HasUnpushed && (wt.PRStatus == "" || wt.PRStatus == "none") {
+	// "no unpushed commits" is a safety note on an existing reason, never a
+	// reason on its own — otherwise every fresh worktree without a PR would
+	// be offered for deletion (and prune --yes would delete it).
+	if len(reasons) > 0 && !wt.HasUnpushed && (wt.PRStatus == "" || wt.PRStatus == "none") {
 		reasons = append(reasons, "no unpushed commits")
 	}
 	return reasons

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -83,7 +83,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 	g.Wait() //nolint:errcheck — goroutines always return nil
 	spin.Stop()
 
-	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9 // nanoseconds
+	staleDur := staleDuration(cfg.StaleThresholdDays)
 
 	var items []tui.Item
 	for _, wt := range worktrees {
@@ -182,6 +182,14 @@ func runClean(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	return nil
 }
+
+// nsPerDay is the number of nanoseconds in a day, used to convert
+// StaleThresholdDays (user-facing config) to a time.Duration-compatible value.
+const nsPerDay = float64(24 * 3600 * 1e9)
+
+// staleDuration converts a day count into the ns-scale float the worktree
+// age comparison expects.
+func staleDuration(days int) float64 { return float64(days) * nsPerDay }
 
 // candidateReasons returns the reasons a worktree is a deletion candidate.
 func candidateReasons(wt *git.Worktree, staleDur float64) []string {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -36,13 +35,6 @@ type doctorIssue struct {
 	detail   string
 	fix      string
 }
-
-var (
-	issueError = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true)
-	issueWarn  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	issueFix   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	issueOK    = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-)
 
 func runDoctor(cmd *cobra.Command, args []string) error {
 	worktrees, err := git.List()
@@ -127,7 +119,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(issues) == 0 {
-		fmt.Printf("%s  All %d worktree(s) are healthy.\n", issueOK.Render("✓"), checked)
+		fmt.Printf("%s  All %d worktree(s) are healthy.\n", okStyle.Render("✓"), checked)
 		return nil
 	}
 
@@ -135,13 +127,13 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	for _, iss := range issues {
 		var sev string
 		if iss.severity == "error" {
-			sev = issueError.Render("✗ error")
+			sev = errBoldStyle.Render("✗ error")
 		} else {
-			sev = issueWarn.Render("⚠ warn")
+			sev = warnStyle.Render("⚠ warn")
 		}
 		fmt.Printf("  %s  %s\n", sev, iss.label)
 		fmt.Printf("         %s\n", iss.detail)
-		fmt.Printf("         %s %s\n\n", issueFix.Render("fix:"), iss.fix)
+		fmt.Printf("         %s %s\n\n", dimStyle.Render("fix:"), iss.fix)
 	}
 	return fmt.Errorf("%d issue(s) found", len(issues))
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -37,6 +37,58 @@ func TestCommandWithPathArgSupportsQuotedArgs(t *testing.T) {
 	}
 }
 
+func TestCandidateReasonsFreshWorktreeIsNotACandidate(t *testing.T) {
+	// A clean worktree with no PR and recent activity must not be offered
+	// for deletion — "no unpushed commits" is not a reason on its own.
+	reasons := candidateReasons(&git.Worktree{
+		Age:         time.Hour,
+		PRStatus:    "none",
+		HasUnpushed: false,
+	}, float64(14*24*time.Hour))
+
+	if len(reasons) != 0 {
+		t.Fatalf("expected no reasons for a fresh clean worktree, got %v", reasons)
+	}
+}
+
+func TestCandidateReasonsStaleCleanWorktree(t *testing.T) {
+	reasons := candidateReasons(&git.Worktree{
+		Age:         30 * 24 * time.Hour,
+		PRStatus:    "none",
+		HasUnpushed: false,
+	}, float64(14*24*time.Hour))
+
+	if len(reasons) != 2 || reasons[0] != "stale (1mo)" || reasons[1] != "no unpushed commits" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
+func TestCandidateReasonsMergedPRIsACandidate(t *testing.T) {
+	reasons := candidateReasons(&git.Worktree{
+		Age:         time.Hour,
+		PRStatus:    "merged",
+		HasUnpushed: false,
+	}, float64(14*24*time.Hour))
+
+	if len(reasons) != 1 || reasons[0] != "merged PR" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
+func TestTruncateLeftKeepsTail(t *testing.T) {
+	got := truncateLeft("/very/long/path/to/worktrees/feature-x", 20)
+	if got != "…worktrees/feature-x" {
+		t.Fatalf("truncateLeft = %q", got)
+	}
+	if short := truncateLeft("wt/feature", 20); short != "wt/feature" {
+		t.Fatalf("short string modified: %q", short)
+	}
+	// Double-width runes must count as 2 columns.
+	if wide := truncateLeft("ここ/日本語/パス", 6); wide != "…/パス" {
+		t.Fatalf("wide truncation = %q", wide)
+	}
+}
+
 func TestCandidateReasonsDoesNotTreatUnknownPRAsNoPR(t *testing.T) {
 	reasons := candidateReasons(&git.Worktree{
 		Age:         time.Hour,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -414,6 +414,25 @@ func truncate(s string, n int) string {
 	return s
 }
 
+// truncateLeft shortens s so its display width is at most n, dropping the
+// head and prepending "…". Use for paths, where the tail is the part that
+// distinguishes entries. Expects plain (non-ANSI) input.
+func truncateLeft(s string, n int) string {
+	if runewidth.StringWidth(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	visWidth := 0
+	for i := len(runes) - 1; i >= 0; i-- {
+		rw := runewidth.RuneWidth(runes[i])
+		if visWidth+rw > n-1 {
+			return "…" + string(runes[i+1:])
+		}
+		visWidth += rw
+	}
+	return s
+}
+
 // stripANSI removes ANSI escape codes, returning the plain visible string.
 func stripANSI(s string) string {
 	var out strings.Builder

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/sauravpanda/bonsai/internal/config"
 	"github.com/sauravpanda/bonsai/internal/git"
@@ -22,7 +22,10 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all git worktrees",
 	Long: `Display a table of all git worktrees with path, branch, age,
-last commit message, ahead/behind the base branch, and PR status.`,
+last commit message, ahead/behind the base branch, and PR status.
+
+Pass --json to emit structured output for scripting; in that mode progress
+messages are suppressed and JSON is written to stdout.`,
 	RunE: runList,
 }
 
@@ -30,6 +33,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().Bool("no-pr", false, "filter: show only worktrees with no PR")
 	listCmd.Flags().Bool("offline", false, "skip GitHub PR status lookup (faster)")
+	listCmd.Flags().Bool("json", false, "emit worktree data as JSON to stdout (no progress output)")
 }
 
 // Fixed column widths.
@@ -63,20 +67,6 @@ func computeCols(diffWidth, numWidth int) cols {
 	return cols{path, branch, commit, diffWidth}
 }
 
-var (
-	headerStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
-	mainStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	prMerged     = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true) // green
-	prOpen       = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))            // yellow
-	prClosed     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))             // red
-	prNone       = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // dim
-	unpushedWarn = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-
-	ageFresh = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // green  — < 3 days
-	ageWarn  = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // yellow — < stale threshold
-	ageStale = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // red    — >= stale threshold
-)
-
 func runList(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load()
 	if err != nil {
@@ -90,15 +80,19 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	filterNoPR, _ := cmd.Flags().GetBool("no-pr")
 	offline, _ := cmd.Flags().GetBool("offline")
+	asJSON, _ := cmd.Flags().GetBool("json")
 	ghOK := !offline && github.IsAvailable()
 
-	if !ghOK && !offline {
+	if !ghOK && !offline && !asJSON {
 		fmt.Fprintln(os.Stderr, "  note: gh CLI not authenticated — PR status unavailable")
 	}
 
 	root, _ := git.MainRoot()
 
-	spin := tui.Start(fmt.Sprintf("enriching %d worktree(s) in parallel…", len(worktrees)))
+	var spin *tui.Spinner
+	if !asJSON {
+		spin = tui.Start(fmt.Sprintf("enriching %d worktree(s) in parallel…", len(worktrees)))
+	}
 	var g errgroup.Group
 	for _, wt := range worktrees {
 		wt := wt
@@ -125,7 +119,9 @@ func runList(cmd *cobra.Command, args []string) error {
 		})
 	}
 	g.Wait() //nolint:errcheck — goroutines always return nil
-	spin.Stop()
+	if spin != nil {
+		spin.Stop()
+	}
 
 	// Apply --no-pr filter: keep main worktree + added worktrees with no PR.
 	if filterNoPR {
@@ -138,14 +134,72 @@ func runList(cmd *cobra.Command, args []string) error {
 		worktrees = filtered
 	}
 
+	if asJSON {
+		return emitJSON(worktrees, root)
+	}
+
 	if len(worktrees) == 0 || (len(worktrees) == 1 && worktrees[0].IsMain) {
 		fmt.Println(mainStyle.Render("  no worktrees match the filter"))
 		return nil
 	}
 
-	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9
+	staleDur := staleDuration(cfg.StaleThresholdDays)
 	printTable(worktrees, root, staleDur)
 	return nil
+}
+
+// jsonWorktree is the JSON shape emitted by `bonsai list --json`.
+type jsonWorktree struct {
+	Number      int    `json:"number,omitempty"`
+	Path        string `json:"path"`
+	ShortPath   string `json:"short_path"`
+	Branch      string `json:"branch"`
+	HEAD        string `json:"head,omitempty"`
+	IsMain      bool   `json:"is_main"`
+	IsDetached  bool   `json:"is_detached,omitempty"`
+	AgeSeconds  int64  `json:"age_seconds"`
+	AgeHuman    string `json:"age_human"`
+	LastCommit  string `json:"last_commit,omitempty"`
+	AheadBase   int    `json:"ahead_base"`
+	BehindBase  int    `json:"behind_base"`
+	PRStatus    string `json:"pr_status,omitempty"`
+	PRURL       string `json:"pr_url,omitempty"`
+	HasUnpushed bool   `json:"has_unpushed"`
+}
+
+func emitJSON(worktrees []*git.Worktree, root string) error {
+	out := make([]jsonWorktree, 0, len(worktrees))
+	addedIdx := 0
+	for _, wt := range worktrees {
+		j := jsonWorktree{
+			Path:        wt.Path,
+			ShortPath:   git.ShortenPath(wt.Path, root),
+			Branch:      wt.Branch,
+			HEAD:        wt.HEAD,
+			IsMain:      wt.IsMain,
+			IsDetached:  wt.IsDetached,
+			AgeSeconds:  int64(wt.Age / time.Second),
+			AgeHuman:    git.FormatAge(wt.Age),
+			LastCommit:  wt.LastCommit,
+			AheadBase:   wt.AheadBase,
+			BehindBase:  wt.BehindBase,
+			PRStatus:    wt.PRStatus,
+			PRURL:       wt.PRURL,
+			HasUnpushed: wt.HasUnpushed,
+		}
+		// The em-dash placeholder used by the table renderer is noise in JSON.
+		if j.PRStatus == "—" {
+			j.PRStatus = ""
+		}
+		if !wt.IsMain {
+			addedIdx++
+			j.Number = addedIdx
+		}
+		out = append(out, j)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
 }
 
 // tableRow holds pre-computed, display-ready cell values for one worktree.
@@ -221,7 +275,7 @@ func printTable(worktrees []*git.Worktree, root string, staleDur float64) {
 	fmt.Println("  " + headerStyle.Render(header))
 	fmt.Println(mainStyle.Render("  " + sep))
 
-	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+	numStyle := infoStyle.Bold(true)
 	for _, r := range rows {
 		numCell := fitCol(r.num, numWidth)
 		if !r.isMain && r.num != "" {
@@ -276,7 +330,7 @@ func colorAge(age time.Duration, staleDur float64, isMain bool) string {
 	if isMain || age == 0 {
 		return mainStyle.Render(s)
 	}
-	const threeDays = float64(3 * 24 * 3600e9)
+	threeDays := staleDuration(3)
 	switch {
 	case float64(age) < threeDays:
 		return ageFresh.Render(s)

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/config"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/sauravpanda/bonsai/internal/github"
@@ -32,13 +31,6 @@ func init() {
 	pruneCmd.Flags().Bool("force", false, "force removal even if worktree is dirty")
 	pruneCmd.Flags().Bool("offline", false, "skip GitHub PR status lookup (faster)")
 }
-
-var (
-	reasonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	warnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	okStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	boldStyle   = lipgloss.NewStyle().Bold(true)
-)
 
 type pruneCandidate struct {
 	wt      *git.Worktree
@@ -68,7 +60,7 @@ func runPrune(cmd *cobra.Command, args []string) error {
 
 	ghOK := !offline && github.IsAvailable()
 	root, _ := git.MainRoot()
-	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9
+	staleDur := staleDuration(cfg.StaleThresholdDays)
 
 	// Collect non-main worktrees and enrich them in parallel.
 	var added []*git.Worktree

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/config"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/spf13/cobra"
@@ -30,8 +29,6 @@ func init() {
 	rmCmd.Flags().Bool("force", false, "remove even if branch has unpushed commits")
 	rmCmd.Flags().Bool("dry-run", false, "show what would be removed without doing it")
 }
-
-var rmDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 
 func runRm(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
@@ -85,8 +82,8 @@ func runRm(cmd *cobra.Command, args []string) error {
 			warnStyle.Render("⚠"))
 		for _, wt := range blocked {
 			fmt.Fprintf(os.Stderr, "  • %s  %s\n",
-				lipgloss.NewStyle().Bold(true).Render(wt.Branch),
-				rmDimStyle.Render(wt.Path))
+				boldStyle.Render(wt.Branch),
+				dimStyle.Render(wt.Path))
 		}
 		fmt.Fprintln(os.Stderr, "\nUse --force to remove them anyway.")
 		return fmt.Errorf("aborted")
@@ -99,12 +96,12 @@ func runRm(cmd *cobra.Command, args []string) error {
 		short := git.ShortenPath(wt.Path, root)
 		if dryRun {
 			fmt.Printf("  [dry-run] remove  %s  %s\n",
-				lipgloss.NewStyle().Bold(true).Render(wt.Branch),
-				rmDimStyle.Render(short))
+				boldStyle.Render(wt.Branch),
+				dimStyle.Render(short))
 			continue
 		}
 		fmt.Printf("  removing  %-28s  %s … ",
-			wt.Branch, rmDimStyle.Render(short))
+			wt.Branch, dimStyle.Render(short))
 		if err := git.Remove(wt.Path, force); err != nil {
 			fmt.Printf("%s\n", warnStyle.Render("failed: "+err.Error()))
 			hadErr = true

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -69,12 +68,6 @@ func snapshotDir() (string, error) {
 	return dir, nil
 }
 
-var (
-	snapBold = lipgloss.NewStyle().Bold(true)
-	snapDim  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	snapOK   = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-)
-
 func runSnapshotCreate(cmd *cobra.Command, args []string) error {
 	worktrees, err := git.List()
 	if err != nil {
@@ -102,7 +95,7 @@ func runSnapshotCreate(cmd *cobra.Command, args []string) error {
 	archiveName := fmt.Sprintf("%s-%s.tar.gz", branch, ts)
 	archivePath := filepath.Join(dir, archiveName)
 
-	fmt.Printf("  creating snapshot of %s … ", snapBold.Render(wt.Branch))
+	fmt.Printf("  creating snapshot of %s … ", boldStyle.Render(wt.Branch))
 
 	if err := createTarGz(wt.Path, archivePath); err != nil {
 		fmt.Println("failed")
@@ -114,7 +107,7 @@ func runSnapshotCreate(cmd *cobra.Command, args []string) error {
 	if info != nil {
 		size = " (" + formatBytes(info.Size()) + ")"
 	}
-	fmt.Printf("%s\n", snapOK.Render("done"))
+	fmt.Printf("%s\n", okStyle.Render("done"))
 	fmt.Printf("  saved to: %s%s\n", archivePath, size)
 	return nil
 }
@@ -138,7 +131,7 @@ func runSnapshotList(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(snapshots) == 0 {
-		fmt.Println(snapDim.Render("  no snapshots found"))
+		fmt.Println(dimStyle.Render("  no snapshots found"))
 		return nil
 	}
 
@@ -147,7 +140,7 @@ func runSnapshotList(cmd *cobra.Command, args []string) error {
 		info, _ := e.Info()
 		size := ""
 		if info != nil {
-			size = " " + snapDim.Render("("+formatBytes(info.Size())+")")
+			size = " " + dimStyle.Render("("+formatBytes(info.Size())+")")
 		}
 		fmt.Printf("  %s%s\n", e.Name(), size)
 	}
@@ -185,7 +178,7 @@ func runSnapshotRestore(cmd *cobra.Command, args []string) error {
 		fmt.Println("failed")
 		return fmt.Errorf("extract archive: %w", err)
 	}
-	fmt.Println(snapOK.Render("done"))
+	fmt.Println(okStyle.Render("done"))
 	return nil
 }
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -101,7 +101,7 @@ func runStats(cmd *cobra.Command, args []string) error {
 	g.Wait() //nolint:errcheck
 	spin.Stop()
 
-	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9
+	staleDur := staleDuration(cfg.StaleThresholdDays)
 
 	var (
 		staleCount    int
@@ -139,21 +139,15 @@ func runStats(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	bold := lipgloss.NewStyle().Bold(true)
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	green := lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	yellow := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	red := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-
-	sep := dim.Render("  " + strings.Repeat("─", 40))
+	sep := dimStyle.Render("  " + strings.Repeat("─", 40))
 	fmt.Println(sep)
-	fmt.Printf("  %s  %s\n", bold.Render("Total worktrees:"), fmt.Sprint(len(added)))
-	fmt.Printf("  %s  %s\n", bold.Render("Stale (≥ threshold): "), staleStyle(staleCount, red))
-	fmt.Printf("  %s  %s\n", bold.Render("Open PRs:            "), staleStyle(openPRCount, green))
-	fmt.Printf("  %s  %s\n", bold.Render("Unpushed commits:    "), staleStyle(unpushedCount, yellow))
-	fmt.Printf("  %s  %s\n", bold.Render("Total disk usage:    "), formatBytes(diskTotal))
+	fmt.Printf("  %s  %s\n", boldStyle.Render("Total worktrees:"), fmt.Sprint(len(added)))
+	fmt.Printf("  %s  %s\n", boldStyle.Render("Stale (≥ threshold): "), staleStyle(staleCount, errStyle))
+	fmt.Printf("  %s  %s\n", boldStyle.Render("Open PRs:            "), staleStyle(openPRCount, okStyle))
+	fmt.Printf("  %s  %s\n", boldStyle.Render("Unpushed commits:    "), staleStyle(unpushedCount, warnStyle))
+	fmt.Printf("  %s  %s\n", boldStyle.Render("Total disk usage:    "), formatBytes(diskTotal))
 	fmt.Println(sep)
-	fmt.Println("  " + bold.Render("Age distribution:"))
+	fmt.Println("  " + boldStyle.Render("Age distribution:"))
 	fmt.Printf("    < 1 day   : %d\n", bucket1d)
 	fmt.Printf("    1-7 days  : %d\n", bucket7d)
 	fmt.Printf("    7-30 days : %d\n", bucket30d)
@@ -164,7 +158,7 @@ func runStats(cmd *cobra.Command, args []string) error {
 
 func staleStyle(n int, nonZeroStyle lipgloss.Style) string {
 	if n == 0 {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render("0")
+		return dimStyle.Render("0")
 	}
 	return nonZeroStyle.Render(fmt.Sprint(n))
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/config"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/sauravpanda/bonsai/internal/tui"
@@ -28,12 +27,6 @@ var statusCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(statusCmd)
 }
-
-var (
-	statusClean   = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // green
-	statusDirty   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // yellow
-	statusStagedS = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // blue
-)
 
 type wtStatus struct {
 	wt        *git.Worktree
@@ -104,20 +97,17 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 	spin.Stop()
 
-	staleDur := float64(cfg.StaleThresholdDays) * 24 * 3600e9
+	staleDur := staleDuration(cfg.StaleThresholdDays)
 
-	hdr := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-
-	fmt.Println(hdr.Render(fmt.Sprintf("  %-28s  %-6s  %-14s  %-8s  %s", "BRANCH", "AGE", "STAGED/DIRTY/UNTRACKED", "+/-", "LAST COMMIT")))
-	fmt.Println(dim.Render("  " + strings.Repeat("─", 90)))
+	fmt.Println(headerStyle.Render(fmt.Sprintf("  %-28s  %-6s  %-14s  %-8s  %s", "BRANCH", "AGE", "STAGED/DIRTY/UNTRACKED", "+/-", "LAST COMMIT")))
+	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 90)))
 
 	for _, s := range statuses {
 		wt := s.wt
 
 		branch := wt.Branch
 		if wt.IsMain {
-			branch = dim.Render(branch)
+			branch = dimStyle.Render(branch)
 		}
 
 		age := colorAge(wt.Age, staleDur, wt.IsMain)
@@ -125,25 +115,25 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 		var stateStr string
 		if wt.IsMain {
-			stateStr = dim.Render("—")
+			stateStr = dimStyle.Render("—")
 		} else {
 			stagedPart := fmt.Sprintf("%d staged", s.staged)
 			dirtyPart := fmt.Sprintf("%d dirty", s.dirty)
 			untrackedPart := fmt.Sprintf("%d untracked", s.untracked)
 			if s.staged > 0 {
-				stagedPart = statusStagedS.Render(stagedPart)
+				stagedPart = infoStyle.Render(stagedPart)
 			} else {
-				stagedPart = dim.Render(stagedPart)
+				stagedPart = dimStyle.Render(stagedPart)
 			}
 			if s.dirty > 0 {
-				dirtyPart = statusDirty.Render(dirtyPart)
+				dirtyPart = warnStyle.Render(dirtyPart)
 			} else {
-				dirtyPart = statusClean.Render(dirtyPart)
+				dirtyPart = okStyle.Render(dirtyPart)
 			}
 			if s.untracked > 0 {
-				untrackedPart = statusDirty.Render(untrackedPart)
+				untrackedPart = warnStyle.Render(untrackedPart)
 			} else {
-				untrackedPart = dim.Render(untrackedPart)
+				untrackedPart = dimStyle.Render(untrackedPart)
 			}
 			stateStr = stagedPart + "  " + dirtyPart + "  " + untrackedPart
 		}
@@ -157,12 +147,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			commit,
 		)
 		if wt.IsMain {
-			fmt.Println(dim.Render(row))
+			fmt.Println(dimStyle.Render(row))
 		} else {
 			fmt.Println(row)
 		}
 	}
 
-	fmt.Println(dim.Render("  " + strings.Repeat("─", 90)))
+	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 90)))
 	return nil
 }

--- a/cmd/styles.go
+++ b/cmd/styles.go
@@ -1,0 +1,34 @@
+package cmd
+
+import "github.com/charmbracelet/lipgloss"
+
+// Centralized palette used by all cmd/ output. Prefer these over redefining
+// locally — new semantic roles belong here, not per-file.
+var (
+	boldStyle = lipgloss.NewStyle().Bold(true)
+	dimStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+
+	okStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	warnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	errStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	infoStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
+
+	okBoldStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
+	errBoldStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))
+
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+
+	// Semantic aliases — kept so call sites read naturally.
+	mainStyle   = dimStyle
+	reasonStyle = dimStyle
+
+	ageFresh = okStyle
+	ageWarn  = warnStyle
+	ageStale = errStyle
+
+	prMerged     = okBoldStyle
+	prOpen       = warnStyle
+	prClosed     = errStyle
+	prNone       = dimStyle
+	unpushedWarn = warnStyle
+)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/sauravpanda/bonsai/internal/config"
 	"github.com/sauravpanda/bonsai/internal/git"
 	"github.com/spf13/cobra"
@@ -34,12 +33,6 @@ func init() {
 	syncCmd.Flags().Bool("merge", false, "use git merge instead of git rebase")
 	syncCmd.Flags().Bool("dry-run", false, "show what would be synced without running")
 }
-
-var (
-	syncOK      = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	syncSkipped = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	syncFailed  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-)
 
 func runSync(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load()
@@ -101,7 +94,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		if dryRun {
 			fmt.Printf("  %-28s  %s\n",
 				truncate(branch, 28),
-				syncSkipped.Render(fmt.Sprintf("[dry-run] would %s from %s", verb, baseRef)),
+				dimStyle.Render(fmt.Sprintf("[dry-run] would %s from %s", verb, baseRef)),
 			)
 			continue
 		}
@@ -119,7 +112,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		outStr := strings.TrimSpace(string(out))
 
 		if err != nil {
-			fmt.Println(syncFailed.Render("failed"))
+			fmt.Println(errStyle.Render("failed"))
 			if outStr != "" {
 				for _, line := range strings.Split(outStr, "\n") {
 					fmt.Printf("    %s\n", line)
@@ -133,16 +126,16 @@ func runSync(cmd *cobra.Command, args []string) error {
 			}
 			failed++
 		} else {
-			fmt.Println(syncOK.Render("ok"))
+			fmt.Println(okStyle.Render("ok"))
 			synced++
 		}
 	}
 
 	if !dryRun {
 		fmt.Printf("\n%s synced, %s skipped, %s failed\n",
-			syncOK.Render(fmt.Sprint(synced)),
-			syncSkipped.Render(fmt.Sprint(skipped)),
-			syncFailed.Render(fmt.Sprint(failed)),
+			okStyle.Render(fmt.Sprint(synced)),
+			dimStyle.Render(fmt.Sprint(skipped)),
+			errStyle.Render(fmt.Sprint(failed)),
 		)
 		if failed > 0 {
 			return fmt.Errorf("%d worktree(s) failed to sync", failed)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -179,6 +180,12 @@ func MainRoot() (string, error) {
 
 func run(name string, args ...string) (string, error) {
 	out, err := exec.Command(name, args...).Output()
+	// Fold git's stderr into the error so callers surface the actual reason
+	// (e.g. "contains modified or untracked files") instead of "exit status 128".
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		err = fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+	}
 	return string(out), err
 }
 

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -10,11 +10,11 @@ import (
 
 // Item represents a worktree entry in the picker.
 type Item struct {
-	ID           string // worktree path (unique key)
-	Label        string // branch name or short path
-	Desc         string // reason line: "merged PR · 21d · no unpushed"
-	Selected     bool
-	HasUnpushed  bool
+	ID          string // worktree path (unique key)
+	Label       string // branch name or short path
+	Desc        string // reason line: "merged PR · 21d · no unpushed"
+	Selected    bool
+	HasUnpushed bool
 }
 
 // Result is returned after the picker exits.
@@ -25,11 +25,11 @@ type Result struct {
 
 // Model is the bubbletea model for the interactive picker.
 type Model struct {
-	title   string
-	items   []Item
-	cursor  int
-	done    bool
-	quit    bool
+	title  string
+	items  []Item
+	cursor int
+	done   bool
+	quit   bool
 }
 
 // NewPicker creates a new picker model.
@@ -73,18 +73,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 var (
-	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
-	helpStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	helpKeyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)
-	focusBarStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
-	focusedStyle  = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(lipgloss.Color("15")).Bold(true)
+	titleStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
+	helpStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	helpKeyStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)
+	focusBarStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+	focusedStyle     = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(lipgloss.Color("15")).Bold(true)
 	focusedDescStyle = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(lipgloss.Color("252"))
-	selectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
-	checkStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
-	normalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
-	descStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	warnStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	selectedStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+	checkStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+	normalStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	descStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	warnStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	dimStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 )
 
 func (m Model) View() string {


### PR DESCRIPTION
## Summary

### Styles, stale math, list --json
- **`cmd/styles.go`**: single semantic palette (`okStyle`, `warnStyle`, `errStyle`, `infoStyle`, `dimStyle`, `boldStyle`, `headerStyle`, semantic aliases for `prMerged`/`ageFresh`/etc.). Removes scattered `lipgloss.NewStyle()` blocks from `list`, `prune`, `stats`, `status`, `doctor`, `sync`, `rm`, `snapshot`.
- **`staleDuration(days int) float64`** and `nsPerDay` constant. Replaces four copies of `float64(cfg.StaleThresholdDays) * 24 * 3600e9`.
- **`bonsai list --json`**: emits a JSON array of worktree objects (`number`, `path`, `short_path`, `branch`, `head`, `age_seconds`, `age_human`, `ahead_base`, `behind_base`, `pr_status`, `pr_url`, `has_unpushed`, `is_main`, `is_detached`). Skips the spinner and the stderr auth note so output pipes cleanly to `jq` and other tools.

### Clean UX fixes
- **Candidate logic**: `candidateReasons()` no longer treats "no unpushed commits" as a standalone deletion reason — it's now a safety note appended only when a real reason (merged PR or stale) exists. Previously a worktree created minutes ago showed up as a deletion candidate, and `prune --yes` would auto-delete every clean no-PR worktree.
- **Path truncation**: picker paths truncate from the left (`…/wt/feature-x`) so the distinguishing tail is visible instead of an identical prefix on every row.
- **Removal errors**: `git worktree remove` failures now surface git's stderr (e.g. `contains modified or untracked files, use --force to delete it`) instead of a bare `exit status 128`.
- **Consistency**: `clean` no longer enriches the main worktree (matches `prune`, fixes the spinner count) and prints shortened paths during removal. `internal/tui/picker.go` gofmt'd.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` pass
- [x] `bonsai list --json --offline | jq '.[].branch'` returns expected values
- [x] `bonsai list` (table mode) unchanged
- [x] New tests: fresh clean worktree is not a candidate, stale + qualifier ordering, merged PR, `truncateLeft` incl. double-width runes
- [x] TUI flows exercised end-to-end in a scratch repo: default view, `--all`, dirty-worktree failure message, unpushed-confirm → successful removal
